### PR TITLE
fix handling of server-deletes resulting in 404s

### DIFF
--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -285,7 +285,7 @@ func (obj *APIObject) readObject() error {
 
 	resultString, err := obj.apiClient.sendRequest(obj.readMethod, strings.Replace(getPath, "{id}", obj.id, -1), "")
 	if err != nil {
-		if strings.Contains(err.Error(), "Unexpected response code '404'") {
+		if strings.Contains(err.Error(), "unexpected response code '404'") {
 			log.Printf("api_object.go: 404 error while refreshing state for '%s' at path '%s'. Removing from state.", obj.id, obj.getPath)
 			obj.id = ""
 			return nil

--- a/restapi/api_object_test.go
+++ b/restapi/api_object_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/Mastercard/terraform-provider-restapi/fakeserver"
@@ -220,11 +219,8 @@ func TestAPIObject(t *testing.T) {
 		}
 		testingObjects["pet"].deleteObject()
 		err = testingObjects["pet"].readObject()
-		if err == nil {
-			t.Fatalf("api_object_test.go: 'pet' object deleted, but a subsequent read did not return an error!\n")
-		}
-		if !strings.Contains(err.Error(), "404") {
-			t.Fatalf("api_object_test.go: 'pet' object deleted, but the resulting error was not a 404 during read! What came back was: %v\n", err)
+		if err != nil {
+			t.Fatalf("api_object_test.go: 'pet' object deleted, but an error was returned when reading the object (expected the provider to cope with this!\n")
 		}
 	})
 


### PR DESCRIPTION
This got broken with ef7f07a2334a87ff50c42625bc63934affbf6646.

Also revert commit c43d333652afa539d5b8c8c42233c96f26f2aaf6 which changed a
test case that is supposed to verify that server-side deletes are handled
gracefully.